### PR TITLE
fix warn when "include_path" includes non-existent path

### DIFF
--- a/lib/Compiler/Lexer.pm
+++ b/lib/Compiler/Lexer.pm
@@ -28,6 +28,7 @@ sub load_module {
     my @include_path = ($inc) ? @$inc : @INC;
     my $module_path = '';
     foreach my $path (@include_path) {
+        next unless -e $path;
         find(sub {
             return if ($module_path);
             my $absolute_path = $File::Find::name;


### PR DESCRIPTION
if @INC includes non-existent path, occurred warnings which is "Can't stat /non/existent/path: No such file or directory".
This patch fixes that small issue.
