### PR TITLE
Support to tokenize whitespace characters on verbose mode

### DIFF
--- a/include/lexer.hpp
+++ b/include/lexer.hpp
@@ -228,6 +228,7 @@ public:
 	Token *scanLineDelimiter(LexContext *ctx);
 	Token *scanNumber(LexContext *ctx);
 	Token *scanVersionString(LexContext *ctx);
+	Token *scanWhiteSpace(LexContext *ctx);
 	bool scanNegativeNumber(LexContext *ctx, char num);
 };
 

--- a/src/compiler/lexer/Compiler_annotator.cpp
+++ b/src/compiler/lexer/Compiler_annotator.cpp
@@ -20,6 +20,10 @@ Annotator::Annotator(void)
 
 void Annotator::annotate(LexContext *ctx, Token *tk)
 {
+	// Ignore WhiteSpace tokens to annotate
+	if (tk->info.type == WhiteSpace) {
+		return;
+	}
 	if (tk->info.type != Undefined) {
 		ctx->prev_type = tk->info.type;
 		return;
@@ -78,7 +82,7 @@ void Annotator::annotateMethod(LexContext *ctx, const string &, Token *tk, Token
 void Annotator::annotateKey(LexContext *ctx, const string &, Token *tk, TokenInfo *info)
 {
 	Token *prev_before_tk = ctx->tmgr->beforePreviousToken(tk);
-	TokenType::Type prev_before_type = (prev_before_tk) ? prev_before_tk->info.type : Undefined; 
+	TokenType::Type prev_before_type = (prev_before_tk) ? prev_before_tk->info.type : Undefined;
 	Token *next_tk = ctx->tmgr->nextToken(tk);
 	if (prev_before_type != Function &&
 		ctx->prev_type == LeftBrace && next_tk &&

--- a/src/compiler/lexer/Compiler_lexer.cpp
+++ b/src/compiler/lexer/Compiler_lexer.cpp
@@ -60,6 +60,7 @@ Tokens *Lexer::tokenize(char *script)
 			break;
 		case ' ': case '\t':
 			tmgr->add(scanner.scanWordDelimiter(ctx));
+			tmgr->add(scanner.scanWhiteSpace(ctx)); // For newline character
 			break;
 		case '#':
 			tmgr->add(scanner.scanSingleLineComment(ctx));
@@ -98,6 +99,7 @@ Tokens *Lexer::tokenize(char *script)
 			break;
 		case '\n':
 			tmgr->add(scanner.scanLineDelimiter(ctx));
+			tmgr->add(scanner.scanWhiteSpace(ctx)); // For newline character
 			break;
 		case '0': case '1': case '2': case '3': case '4':
 		case '5': case '6': case '7': case '8': case '9':

--- a/t/verbose.t
+++ b/t/verbose.t
@@ -15,6 +15,10 @@ my $var;
 =head2
 
 =cut
+my  $foo = <<"        --";
+            print "Hello";
+            print "Goodbye";
+        --
 SCRIPT
 subtest 'tokenize' => sub {
     is_deeply($tokens, [
@@ -28,12 +32,31 @@ subtest 'tokenize' => sub {
             'line' => 1
         }, 'Compiler::Lexer::Token' ),
         bless( {
+            'kind' => Compiler::Lexer::Kind::T_Verbose,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'WhiteSpace',
+            'data' => '
+',
+            'type' => Compiler::Lexer::TokenType::T_WhiteSpace,
+            'line' => 1
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
             'kind' => Compiler::Lexer::Kind::T_Decl,
             'has_warnings' => 0,
             'stype' => 0,
             'name' => 'VarDecl',
             'data' => 'my',
             'type' => Compiler::Lexer::TokenType::T_VarDecl,
+            'line' => 2
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Verbose,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'WhiteSpace',
+            'data' => ' ',
+            'type' => Compiler::Lexer::TokenType::T_WhiteSpace,
             'line' => 2
         }, 'Compiler::Lexer::Token' ),
         bless( {
@@ -58,6 +81,16 @@ subtest 'tokenize' => sub {
             'kind' => Compiler::Lexer::Kind::T_Verbose,
             'has_warnings' => 0,
             'stype' => 0,
+            'name' => 'WhiteSpace',
+            'data' => '
+',
+            'type' => Compiler::Lexer::TokenType::T_WhiteSpace,
+            'line' => 2
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Verbose,
+            'has_warnings' => 0,
+            'stype' => 0,
             'name' => 'Pod',
             'data' => '=pod
 
@@ -68,7 +101,138 @@ subtest 'tokenize' => sub {
 ',
             'type' => Compiler::Lexer::TokenType::T_Pod,
             'line' => 9
-        }, 'Compiler::Lexer::Token' )
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Verbose,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'WhiteSpace',
+            'data' => '
+',
+            'type' => Compiler::Lexer::TokenType::T_WhiteSpace,
+            'line' => 9
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Decl,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'VarDecl',
+            'data' => 'my',
+            'type' => Compiler::Lexer::TokenType::T_VarDecl,
+            'line' => 10
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Verbose,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'WhiteSpace',
+            'data' => '  ',
+            'type' => Compiler::Lexer::TokenType::T_WhiteSpace,
+            'line' => 10
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Term,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'LocalVar',
+            'data' => '$foo',
+            'type' => Compiler::Lexer::TokenType::T_LocalVar,
+            'line' => 10
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Verbose,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'WhiteSpace',
+            'data' => ' ',
+            'type' => Compiler::Lexer::TokenType::T_WhiteSpace,
+            'line' => 10
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Assign,
+            'has_warnings' => 0,
+            'stype' => Compiler::Lexer::SyntaxType::T_Value,
+            'name' => 'Assign',
+            'data' => '=',
+            'type' => Compiler::Lexer::TokenType::T_Assign,
+            'line' => 10
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Verbose,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'WhiteSpace',
+            'data' => ' ',
+            'type' => Compiler::Lexer::TokenType::T_WhiteSpace,
+            'line' => 10
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Operator,
+            'has_warnings' => 0,
+            'stype' => Compiler::Lexer::SyntaxType::T_Value,
+            'name' => 'LeftShift',
+            'data' => '<<',
+            'type' => Compiler::Lexer::TokenType::T_LeftShift,
+            'line' => 10
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Term,
+            'has_warnings' => 0,
+            'stype' => Compiler::Lexer::SyntaxType::T_Value,
+            'name' => 'HereDocumentTag',
+            'data' => '        --',
+            'type' => Compiler::Lexer::TokenType::T_HereDocumentTag,
+            'line' => 10
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_StmtEnd,
+            'has_warnings' => 0,
+            'stype' => Compiler::Lexer::SyntaxType::T_Value,
+            'name' => 'SemiColon',
+            'data' => ';',
+            'type' => Compiler::Lexer::TokenType::T_SemiColon,
+            'line' => 10
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Verbose,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'WhiteSpace',
+            'data' => '
+',
+            'type' => Compiler::Lexer::TokenType::T_WhiteSpace,
+            'line' => 10
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Term,
+            'has_warnings' => 0,
+            'stype' => Compiler::Lexer::SyntaxType::T_Value,
+            'name' => 'HereDocument',
+            'data' => '            print "Hello";
+            print "Goodbye";
+',
+            'type' => Compiler::Lexer::TokenType::T_HereDocument,
+            'line' => 13
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Term,
+            'has_warnings' => 0,
+            'stype' => Compiler::Lexer::SyntaxType::T_Value,
+            'name' => 'HereDocumentEnd',
+            'data' => '        --',
+            'type' => Compiler::Lexer::TokenType::T_HereDocumentEnd,
+            'line' => 13
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Verbose,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'WhiteSpace',
+            'data' => '
+',
+            'type' => Compiler::Lexer::TokenType::T_WhiteSpace,
+            'line' => 13
+        }, 'Compiler::Lexer::Token' ),
     ]);
 };
 


### PR DESCRIPTION
Hello,

I implemented the feature to support to tokenize whitespace characters on verbose mode.
(The function which takes out `newline` may be unnecessary...)

Could you review this?
