### PR TITLE
Include '=cut' at tail of Pod token.

### DIFF
--- a/include/lexer.hpp
+++ b/include/lexer.hpp
@@ -161,6 +161,13 @@ public:
 		token_buffer[buffer_idx] = EOL;
 	}
 
+	inline void writeBuffer(const char *str) {
+		for (size_t i = 0; str[i] != EOL; i++) {
+			token_buffer[buffer_idx++] = str[i];
+		}
+		token_buffer[buffer_idx] = EOL;
+	}
+
 	inline bool existsBuffer(void) {
 		return token_buffer[0] != EOL;
 	}

--- a/src/compiler/lexer/Compiler_scanner.cpp
+++ b/src/compiler/lexer/Compiler_scanner.cpp
@@ -639,6 +639,7 @@ bool Scanner::isSkip(LexContext *ctx)
 			ret = false;
 			if (verbose) {
 				ctx->finfo.start_line_num++;
+				ctx->writeBuffer("=cut");
 				Token *tk = tmgr->new_Token(ctx->buffer(), ctx->finfo);
 				tk->info = tmgr->getTokenInfo(TokenType::Pod);
 				ctx->clearBuffer();

--- a/t/verbose.t
+++ b/t/verbose.t
@@ -98,7 +98,7 @@ subtest 'tokenize' => sub {
 
 =head2
 
-',
+=cut',
             'type' => Compiler::Lexer::TokenType::T_Pod,
             'line' => 9
         }, 'Compiler::Lexer::Token' ),


### PR DESCRIPTION
And a secondary effect, it fixes wrong newline character treatment of Pod.

I have no smart ideas, so this implement looks unfashionable...
How about you?
