### PR TITLE
Fix some PODs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Compiler::Lexer - Lexical Analyzer for Perl5
     create new instance.
     You can create object from $options in hash reference.
 
-    #### options list
+    __options list__
 
     - filename
-    - verbose : includes token of Pod or Comment
+    - verbose : includes token of Pod, Comment and WhiteSpace
 
 - $lexer->tokenize($script);
 

--- a/lib/Compiler/Lexer.pm
+++ b/lib/Compiler/Lexer.pm
@@ -81,6 +81,8 @@ sub __recursive_tokenize {
 1;
 __END__
 
+=encoding utf-8
+
 =head1 NAME
 
 Compiler::Lexer - Lexical Analyzer for Perl5
@@ -103,20 +105,20 @@ Compiler::Lexer - Lexical Analyzer for Perl5
 
 =head1 METHODS
 
-=over
+=over 4
 
 =item my $lexer = Compiler::Lexer->new($options);
 
 create new instance.
 You can create object from $options in hash reference.
 
-=head4 options list
+B<options list>
 
-=over
+=over 4
 
 =item filename
 
-=item verbose : includes token of Pod or Comment
+=item verbose : includes token of Pod, Comment and WhiteSpace
 
 =back
 

--- a/lib/Compiler/Lexer/Token.pm
+++ b/lib/Compiler/Lexer/Token.pm
@@ -26,6 +26,10 @@ my $FIELDS = [qw/
 1;
 __END__
 
+=encoding utf-8
+
+=for stopwords stype
+
 =head1 NAME
 
 Compiler::Lexer::Token


### PR DESCRIPTION
- Fix to pass tests
- Change contents to be suitable for now

perlpod cannot understand `=head` that is in `=over` and `=back`. This is spec of perlpod I think.
Thus I changed like; 
https://github.com/moznion/p5-Compiler-Lexer/compare/fix;pod?expand=1#diff-0d7cea5ad666fc43115444eb30bf2147R115

Please review it!
