### PR TITLE
Fix usage of strict/warnings in Compiler::Lexer::Constants

### DIFF
--- a/lib/Compiler/Lexer/Constants.pm
+++ b/lib/Compiler/Lexer/Constants.pm
@@ -1,6 +1,7 @@
-package Compiler::Lexer::TokenType;
 use strict;
 use warnings;
+
+package Compiler::Lexer::TokenType;
 use constant {
     T_Return => 0,
     T_Add => 1,
@@ -211,11 +212,8 @@ use constant {
     T_WhiteSpace => 206,
     T_Undefined => 207
 };
-1;
 
 package Compiler::Lexer::SyntaxType;
-use strict;
-use warnings;
 use constant {
     T_Value => 0,
     T_Term => 1,
@@ -223,11 +221,8 @@ use constant {
     T_Stmt => 3,
     T_BlockStmt => 4
 };
-1;
 
 package Compiler::Lexer::Kind;
-use strict;
-use warnings;
 use constant {
     T_Return => 0,
     T_Operator => 1,
@@ -267,4 +262,5 @@ use constant {
     T_Verbose => 35,
     T_Undefined => 36
 };
+
 1;


### PR DESCRIPTION
This patch:
- puts a single `use strict; use warnings;` at the top of the file and removes all instances in each package.
- removes every `1;` line except the last of the file.

Because:
- `use strict` and `use warnings` are lexical. `package` doesn't define a new lexical scope. So using `use strict; use warnings;` just once at the top of the file is enough: it will apply to the whole compilation unit, not just to the first package.
- In a similar way the true value (usually `1;`) required at the end of a module only applies to the last statement of the _file_, not as the last statement of a package (because such a thing doesn't exist anyway).
