### PR TITLE
Fix including header files

### DIFF
--- a/include/common.hpp
+++ b/include/common.hpp
@@ -1,7 +1,7 @@
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <stdint.h>
-#include <memory.h>
 #include <iostream>
 #include <vector>
 #include <string>


### PR DESCRIPTION
- Use cstdio, cstdlib instead of stdio.h, stdlib.h.
- Include cstring instead of memory.h. memory.h is not standard header file

Please see this patch
