### PR TITLE
Fix handling for format declaration

### DIFF
--- a/include/lexer.hpp
+++ b/include/lexer.hpp
@@ -191,7 +191,7 @@ public:
 	bool isRegexStarted;
 	bool isPrototypeStarted;
 	bool isFormatStarted;
-	bool isFormatDeclared;
+	Token *formatDeclaredToken;
 	bool commentFlag;
 	bool hereDocumentFlag;
 	bool skipFlag;

--- a/t/format.t
+++ b/t/format.t
@@ -4,7 +4,8 @@ use Data::Dumper;
 use Test::More;
 BEGIN { use_ok('Compiler::Lexer') };
 
-my $tokens = Compiler::Lexer->new('')->tokenize(<<'SCRIPT');
+subtest 'tokenize' => sub {
+    my $tokens = Compiler::Lexer->new('')->tokenize(<<'SCRIPT');
 format STDOUT =
 ok @<<<<<<<
 $test
@@ -12,7 +13,6 @@ $test
 my $hoge;
 SCRIPT
 
-subtest 'tokenize' => sub {
     is_deeply($tokens, [
         bless( {
             'kind' => Compiler::Lexer::Kind::T_Decl,
@@ -87,6 +87,252 @@ $test
             'data' => ';',
             'type' => Compiler::Lexer::TokenType::T_SemiColon,
             'line' => 4
+        }, 'Compiler::Lexer::Token' )
+    ]);
+};
+
+subtest 'omitted handler name' => sub {
+    my $tokens = Compiler::Lexer->new('')->tokenize(<<'SCRIPT');
+format =
+ok @<<<<<<<
+$test
+.
+my $hoge;
+SCRIPT
+
+    is_deeply($tokens, [
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Decl,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'FormatDecl',
+            'data' => 'format',
+            'type' => Compiler::Lexer::TokenType::T_FormatDecl,
+            'line' => 1
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Assign,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'Assign',
+            'data' => '=',
+            'type' => Compiler::Lexer::TokenType::T_Assign,
+            'line' => 1
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Term,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'Format',
+            'data' => 'ok @<<<<<<<
+$test
+',
+            'type' => Compiler::Lexer::TokenType::T_Format,
+            'line' => 4
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Term,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'FormatEnd',
+            'data' => '.',
+            'type' => Compiler::Lexer::TokenType::T_FormatEnd,
+            'line' => 4
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Decl,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'VarDecl',
+            'data' => 'my',
+            'type' => Compiler::Lexer::TokenType::T_VarDecl,
+            'line' => 4
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Term,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'LocalVar',
+            'data' => '$hoge',
+            'type' => Compiler::Lexer::TokenType::T_LocalVar,
+            'line' => 4
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_StmtEnd,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'SemiColon',
+            'data' => ';',
+            'type' => Compiler::Lexer::TokenType::T_SemiColon,
+            'line' => 4
+        }, 'Compiler::Lexer::Token' )
+    ]);
+};
+
+subtest 'do not misrecognize when confusing case' => sub {
+    my $tokens = Compiler::Lexer->new('')->tokenize(<<'SCRIPT');
+my $foo = {
+    format => 1,
+};
+
+my $bar =
+  "asdf";
+1;
+SCRIPT
+
+    is_deeply($tokens, [
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Decl,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'VarDecl',
+            'data' => 'my',
+            'type' => Compiler::Lexer::TokenType::T_VarDecl,
+            'line' => 1,
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Term,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'LocalVar',
+            'data' => '$foo',
+            'type' => Compiler::Lexer::TokenType::T_LocalVar,
+            'line' => 1,
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Assign,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'Assign',
+            'data' => '=',
+            'type' => Compiler::Lexer::TokenType::T_Assign,
+            'line' => 1,
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Symbol,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'LeftBrace',
+            'data' => '{',
+            'type' => Compiler::Lexer::TokenType::T_LeftBrace,
+            'line' => 1,
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Term,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'Key',
+            'data' => 'format',
+            'type' => Compiler::Lexer::TokenType::T_Key,
+            'line' => 2,
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Operator,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'Arrow',
+            'data' => '=>',
+            'type' => Compiler::Lexer::TokenType::T_Arrow,
+            'line' => 2,
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Term,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'Int',
+            'data' => '1',
+            'type' => Compiler::Lexer::TokenType::T_Int,
+            'line' => 2,
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Comma,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'Comma',
+            'data' => ',',
+            'type' => Compiler::Lexer::TokenType::T_Comma,
+            'line' => 2,
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Symbol,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'RightBrace',
+            'data' => '}',
+            'type' => Compiler::Lexer::TokenType::T_RightBrace,
+            'line' => 3,
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_StmtEnd,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'SemiColon',
+            'data' => ';',
+            'type' => Compiler::Lexer::TokenType::T_SemiColon,
+            'line' => 3,
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Decl,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'VarDecl',
+            'data' => 'my',
+            'type' => Compiler::Lexer::TokenType::T_VarDecl,
+            'line' => 5,
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Term,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'LocalVar',
+            'data' => '$bar',
+            'type' => Compiler::Lexer::TokenType::T_LocalVar,
+            'line' => 5,
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Assign,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'Assign',
+            'data' => '=',
+            'type' => Compiler::Lexer::TokenType::T_Assign,
+            'line' => 5,
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Term,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'String',
+            'data' => 'asdf',
+            'type' => Compiler::Lexer::TokenType::T_String,
+            'line' => 6,
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_StmtEnd,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'SemiColon',
+            'data' => ';',
+            'type' => Compiler::Lexer::TokenType::T_SemiColon,
+            'line' => 6,
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_Term,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'Int',
+            'data' => '1',
+            'type' => Compiler::Lexer::TokenType::T_Int,
+            'line' => 7,
+        }, 'Compiler::Lexer::Token' ),
+        bless( {
+            'kind' => Compiler::Lexer::Kind::T_StmtEnd,
+            'has_warnings' => 0,
+            'stype' => 0,
+            'name' => 'SemiColon',
+            'data' => ';',
+            'type' => Compiler::Lexer::TokenType::T_SemiColon,
+            'line' => 7,
         }, 'Compiler::Lexer::Token' )
     ]);
 };


### PR DESCRIPTION
If `format` is used at non declaration context (for example: key of a hash),
it makes incapable of tokenizing action. It breaks structure of tokens.

I'll show an example code to reproduce;

```perl
my $foo = {
    format => 1,  # <= here's format is misrecognized as a FormatDecl
};

my $bar =  # <= code which is after assign operator will be broken
  "asdf";
1;
```

When tokenizing this code, result of it will be broken
because `format` which is a key of hash is misrecognized as a `FormatDecl`.
So I fixed it.