### PR TITLE
Fix handling for `if` which is used at `use` decl

### DIFF
--- a/src/compiler/lexer/Compiler_annotator.cpp
+++ b/src/compiler/lexer/Compiler_annotator.cpp
@@ -169,6 +169,18 @@ void Annotator::annotateHandleDelimiter(LexContext *ctx, const string &, Token *
 void Annotator::annotateReservedKeyword(LexContext *ctx, const string &, Token *tk, TokenInfo *info)
 {
 	TokenInfo reserved_info = ctx->tmgr->getTokenInfo(tk->_data);
+
+	TokenManager *tmgr = ctx->tmgr;
+	Token *prev_tk = tmgr->previousToken(tk);
+	if (reserved_info.type == IfStmt && prev_tk->info.type == UseDecl) {
+		// For `if` statement which is used at `use` declaration.
+		// It should be treated as a `UsedName` instead of `IfStmt`.
+		// e.g.
+		//     use if $] < 5.009_005, 'MRO::Compat';
+		*info = tmgr->getTokenInfo(UsedName);
+		return;
+	}
+
 	if (reserved_info.type != TokenType::Undefined && ctx->prev_type != FunctionDecl) {
 		*info = reserved_info;
 	}

--- a/t/perl/op/coreamp.t
+++ b/t/perl/op/coreamp.t
@@ -27366,12 +27366,12 @@ The problem is that I cannot solve it.
                    'line' => 618
                  }, 'Compiler::Lexer::Token' ),
           bless( {
-                   'kind' => Compiler::Lexer::Kind::T_Stmt,
+                   'kind' => Compiler::Lexer::Kind::T_Module,
                    'has_warnings' => 0,
                    'stype' => Compiler::Lexer::SyntaxType::T_Value,
-                   'name' => 'IfStmt',
+                   'name' => 'UsedName',
                    'data' => 'if',
-                   'type' => Compiler::Lexer::TokenType::T_IfStmt,
+                   'type' => Compiler::Lexer::TokenType::T_UsedName,
                    'line' => 618
                  }, 'Compiler::Lexer::Token' ),
           bless( {
@@ -27492,12 +27492,12 @@ The problem is that I cannot solve it.
                    'line' => 619
                  }, 'Compiler::Lexer::Token' ),
           bless( {
-                   'kind' => Compiler::Lexer::Kind::T_Stmt,
+                   'kind' => Compiler::Lexer::Kind::T_Module,
                    'has_warnings' => 0,
                    'stype' => Compiler::Lexer::SyntaxType::T_Value,
-                   'name' => 'IfStmt',
+                   'name' => 'UsedName',
                    'data' => 'if',
-                   'type' => Compiler::Lexer::TokenType::T_IfStmt,
+                   'type' => Compiler::Lexer::TokenType::T_UsedName,
                    'line' => 619
                  }, 'Compiler::Lexer::Token' ),
           bless( {


### PR DESCRIPTION
`if` which is used at `use` declaration should be treated as a `UsedName` instead of `IfStmt`.

e.g.
```perl
use if $] < 5.009_005, 'MRO::Compat';
```